### PR TITLE
[Fix] Displays map controllers on the right side

### DIFF
--- a/client/app/map/mapService.js
+++ b/client/app/map/mapService.js
@@ -7,7 +7,21 @@ mapMod // = angular.module('myApp.mapServices',[])
         lat: 0,
         lng: 0
       },
-    zoom: 4
+    zoom: 4,
+    mapTypeControl: true,
+    mapTypeControlOptions: {
+        style: google.maps.MapTypeControlStyle.HORIZONTAL_BAR,
+        position: google.maps.ControlPosition.TOP_RIGHT
+    },
+    zoomControl: true,
+    zoomControlOptions: {
+        position: google.maps.ControlPosition.RIGHT_TOP
+    },
+    scaleControl: true,
+    streetViewControl: true,
+    streetViewControlOptions: {
+        position: google.maps.ControlPosition.RIGHT_TOP
+    }
   };
 
   // var marker;


### PR DESCRIPTION
This makes it so that the map controls are not covered by the Turf logo.
